### PR TITLE
Add SmtpSetting Entity, Repository, and Tests with Development Profile Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,20 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>annotationProcessor</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSetting.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSetting.java
@@ -1,0 +1,43 @@
+package com.clinicwave.clinicwavenotificationservice.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * This class represents the SmtpSetting entity.
+ *
+ * @author aamir on 7/8/24
+ */
+@Entity
+@Table(name = "SmtpSetting")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class SmtpSetting {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String host;
+
+  @Column(nullable = false)
+  private Integer port;
+
+  @Column(nullable = false)
+  private String username;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(nullable = false)
+  private Boolean auth = true;
+
+  @Column(nullable = false)
+  private Boolean starttlsEnable = true;
+
+  @Column(nullable = false)
+  private Boolean isActive = true;
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/repository/SmtpSettingRepository.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/repository/SmtpSettingRepository.java
@@ -1,0 +1,15 @@
+package com.clinicwave.clinicwavenotificationservice.repository;
+
+import com.clinicwave.clinicwavenotificationservice.domain.SmtpSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * This interface is a repository for the SmtpSetting entity.
+ *
+ * @author aamir on 7/8/24
+ */
+public interface SmtpSettingRepository extends JpaRepository<SmtpSetting, Long> {
+  Optional<SmtpSetting> findByIsActiveTrue();
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,11 @@
+# Datasource configuration
+spring.datasource.url=jdbc:h2:mem:clinicwave-notification
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# H2 console configuration
+spring.h2.console.enabled=true
+
+# JPA database platform configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@ spring.application.name=clinicwave-notification-service
 
 # Server Port
 server.port=8081
+
+# Active profile
+spring.profiles.active=dev

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSettingTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSettingTest.java
@@ -1,0 +1,110 @@
+package com.clinicwave.clinicwavenotificationservice.domain;
+
+import com.clinicwave.clinicwavenotificationservice.repository.SmtpSettingRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class is a test class for the SmtpSetting entity.
+ *
+ * @author aamir on 7/10/24
+ */
+@SpringBootTest
+class SmtpSettingTest {
+  private final SmtpSettingRepository smtpSettingRepository;
+  private SmtpSetting smtpSetting;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param smtpSettingRepository The repository for SmtpSetting entities.
+   */
+  @Autowired
+  public SmtpSettingTest(SmtpSettingRepository smtpSettingRepository) {
+    this.smtpSettingRepository = smtpSettingRepository;
+  }
+
+  /**
+   * Set up method that runs before each test.
+   */
+  @BeforeEach
+  void setUp() {
+    smtpSetting = new SmtpSetting();
+    smtpSetting.setHost("smtp.gmail.com");
+    smtpSetting.setPort(587);
+    smtpSetting.setUsername("aamirshaikh3232@gmail.com");
+    smtpSetting.setPassword("password");
+    smtpSetting.setAuth(true);
+    smtpSetting.setStarttlsEnable(true);
+    smtpSetting.setIsActive(true);
+    smtpSettingRepository.save(smtpSetting);
+  }
+
+  /**
+   * Tear down method that runs after each test.
+   */
+  @AfterEach
+  void tearDown() {
+    smtpSettingRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("Test save SmtpSetting")
+  void testSaveSmtpSetting() {
+    smtpSettingRepository.save(smtpSetting);
+    assertNotNull(smtpSetting.getId());
+  }
+
+  @Test
+  @DisplayName("Test get SmtpSetting")
+  void testGetSmtpSetting() {
+    smtpSettingRepository.save(smtpSetting);
+    SmtpSetting savedSmtpSetting = smtpSettingRepository.findById(smtpSetting.getId()).orElse(null);
+    assertNotNull(savedSmtpSetting);
+    assertEquals(smtpSetting.getHost(), savedSmtpSetting.getHost());
+    assertEquals(smtpSetting.getPort(), savedSmtpSetting.getPort());
+    assertEquals(smtpSetting.getUsername(), savedSmtpSetting.getUsername());
+    assertEquals(smtpSetting.getPassword(), savedSmtpSetting.getPassword());
+    assertEquals(smtpSetting.getAuth(), savedSmtpSetting.getAuth());
+    assertEquals(smtpSetting.getStarttlsEnable(), savedSmtpSetting.getStarttlsEnable());
+    assertEquals(smtpSetting.getIsActive(), savedSmtpSetting.getIsActive());
+  }
+
+  @Test
+  @DisplayName("Test update SmtpSetting")
+  void testUpdateSmtpSetting() {
+    smtpSettingRepository.save(smtpSetting);
+    smtpSetting.setHost("smtp.mailtrap.io");
+    smtpSetting.setPort(2525);
+    smtpSetting.setUsername("johndoe@email.com");
+    smtpSetting.setPassword("password123");
+    smtpSetting.setAuth(false);
+    smtpSetting.setStarttlsEnable(false);
+    smtpSetting.setIsActive(false);
+    smtpSettingRepository.save(smtpSetting);
+    SmtpSetting updatedSmtpSetting = smtpSettingRepository.findById(smtpSetting.getId()).orElse(null);
+    assertNotNull(updatedSmtpSetting);
+    assertEquals(smtpSetting.getHost(), updatedSmtpSetting.getHost());
+    assertEquals(smtpSetting.getPort(), updatedSmtpSetting.getPort());
+    assertEquals(smtpSetting.getUsername(), updatedSmtpSetting.getUsername());
+    assertEquals(smtpSetting.getPassword(), updatedSmtpSetting.getPassword());
+    assertEquals(smtpSetting.getAuth(), updatedSmtpSetting.getAuth());
+    assertEquals(smtpSetting.getStarttlsEnable(), updatedSmtpSetting.getStarttlsEnable());
+    assertEquals(smtpSetting.getIsActive(), updatedSmtpSetting.getIsActive());
+  }
+
+  @Test
+  @DisplayName("Test delete SmtpSetting")
+  void testDeleteSmtpSetting() {
+    smtpSettingRepository.save(smtpSetting);
+    smtpSettingRepository.deleteById(smtpSetting.getId());
+    SmtpSetting deletedSmtpSetting = smtpSettingRepository.findById(smtpSetting.getId()).orElse(null);
+    assertNull(deletedSmtpSetting);
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces several key additions and updates to the ClinicWave Notification Service project. It adds new dependencies, creates the `SmtpSetting` entity and repository, introduces unit tests for the `SmtpSetting` entity, and configures application properties for development. These changes are aimed at enhancing the project's email notification capabilities and improving the development environment setup.

### Changes:
- Added Lombok, Spring Data JPA, and H2 Database dependencies to simplify codebase and facilitate database interactions.
- Added the `SmtpSetting` entity class to represent SMTP settings in the database.
- Added the `SmtpSettingRepository` interface to provide CRUD operations for `SmtpSetting` entities.
- Added unit tests for the `SmtpSetting` entity to ensure the functionality of CRUD operations.
- Added a new `application-dev.properties` file for development-specific configurations and updated the `application.properties` file to set the active Spring profile to `dev`.

### Purpose:
The purpose of this pull request is to lay the groundwork for implementing email notifications within the ClinicWave Notification Service by introducing the necessary backend components (`SmtpSetting` entity and repository) and ensuring they are thoroughly tested. Additionally, by configuring the development environment with specific properties and dependencies, this PR aims to streamline the development process, making it easier for developers to work on the project and test changes locally. This holistic approach ensures that the project is well-prepared for future features and enhancements related to email notifications and other functionalities.