### PR TITLE
Integrate MailHog for Local SMTP Testing and Update SMTP Configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+    mailhog:
+        image: mailhog/mailhog:latest
+        restart: always
+        ports:
+            - "1025:1025"
+            - "8025:8025"

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
@@ -33,12 +33,12 @@ public class SmtpSettingConfig {
   public void initializeSmtpSettings() {
     if (smtpSettingRepository.count() == 0) {
       SmtpSetting smtpSetting = new SmtpSetting();
-      smtpSetting.setHost("smtp.gmail.com");
-      smtpSetting.setPort(587);
-      smtpSetting.setUsername("aamirshaikh3232@gmail.com");
-      smtpSetting.setPassword("password");
-      smtpSetting.setAuth(true);
-      smtpSetting.setStarttlsEnable(true);
+      smtpSetting.setHost("localhost");
+      smtpSetting.setPort(1025);
+      smtpSetting.setUsername("");
+      smtpSetting.setPassword("");
+      smtpSetting.setAuth(false);
+      smtpSetting.setStarttlsEnable(false);
       smtpSetting.setIsActive(true);
       smtpSettingRepository.save(smtpSetting);
     }


### PR DESCRIPTION
### Description:
This pull request introduces significant enhancements to the local development environment by integrating MailHog, a local SMTP testing tool, and updating the SMTP settings configuration to align with local testing requirements. These changes facilitate easier and more efficient testing of email functionalities within the application.

### Changes:
- Added a `docker-compose.yml` file with MailHog service configuration, enabling local SMTP testing.
- Updated the `SmtpSettingConfig` class to use `localhost` and port `1025` for SMTP, with authentication and STARTTLS disabled, to accommodate MailHog's testing environment.

### Purpose:
The purpose of this pull request is to streamline the email testing process during development by incorporating MailHog into our local setup. This allows developers to test email notifications without the need for an external SMTP server, thereby improving the speed and reliability of developing email-related features. By updating the SMTP settings to match MailHog's requirements, we ensure a seamless integration that simplifies the testing workflow, making it more efficient and less prone to errors related to email sending and receiving during development.