### PR TITLE
Add Exception Handling in Notification Service

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/dto/ValidationErrorResponseDto.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/dto/ValidationErrorResponseDto.java
@@ -1,0 +1,28 @@
+package com.clinicwave.clinicwavenotificationservice.dto;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * A DTO (Data Transfer Object) for validation error responses.
+ * This is used to standardize the structure of validation error responses sent by the API.
+ *
+ * @author aamir on 6/24/24
+ */
+public record ValidationErrorResponseDto(
+        // The API path where the error occurred
+        String apiPath,
+
+        // The HTTP status code of the error
+        Integer httpStatusCode,
+
+        // The error message
+        String errorMessage,
+
+        // The timestamp when the error occurred
+        LocalDateTime errorTimestamp,
+
+        // A map of field names to error messages
+        Map<String, String> errors
+) {
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/EmailSendingException.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/EmailSendingException.java
@@ -1,0 +1,26 @@
+package com.clinicwave.clinicwavenotificationservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This exception is thrown when an email fails to send.
+ * It is annotated with @ResponseStatus to automatically return a HttpStatus.SERVICE_UNAVAILABLE when thrown.
+ * The exception takes in recipient, subject, and errorDetails as parameters to construct a detailed error message.
+ *
+ * @author aamir on 7/14/24
+ */
+@ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE, reason = "Email Sending Failed")
+public class EmailSendingException extends RuntimeException {
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param recipient    The recipient of the email.
+   * @param subject      The subject of the email.
+   * @param errorDetails The details of the error that occurred.
+   */
+  public EmailSendingException(String recipient, String subject, String errorDetails) {
+    super(String.format("Failed to send email to '%s' with subject '%s'. Error: %s", recipient, subject, errorDetails)
+    );
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/GlobalExceptionHandler.java
@@ -1,13 +1,22 @@
 package com.clinicwave.clinicwavenotificationservice.exception;
 
 import com.clinicwave.clinicwavenotificationservice.dto.ErrorResponseDto;
+import com.clinicwave.clinicwavenotificationservice.dto.ValidationErrorResponseDto;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This class is a global exception handler for the application.
@@ -20,7 +29,7 @@ import java.time.LocalDateTime;
  * @author aamir on 7/8/24
  */
 @ControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   /**
    * Handles all types of exceptions.
    */
@@ -41,6 +50,44 @@ public class GlobalExceptionHandler {
           WebRequest webRequest
   ) {
     return createErrorResponse(exception, webRequest, HttpStatus.NOT_FOUND);
+  }
+
+  /**
+   * Handles MethodArgumentNotValidException.
+   * This exception is thrown when validation on an argument annotated with @Valid fails.
+   *
+   * @param exception  the exception that was thrown
+   * @param headers    the headers for the response
+   * @param status     the status code for the response
+   * @param webRequest the current web request
+   * @return a response entity containing a ValidationErrorResponseDto
+   */
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+          MethodArgumentNotValidException exception,
+          @NonNull HttpHeaders headers,
+          HttpStatusCode status,
+          WebRequest webRequest
+  ) {
+    Map<String, String> errors = exception.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .filter(error -> error.getDefaultMessage() != null)
+            .collect(Collectors.toMap(
+                    FieldError::getField,
+                    FieldError::getDefaultMessage,
+                    (existing, replacement) -> existing
+            ));
+
+    ValidationErrorResponseDto validationErrorResponseDto = new ValidationErrorResponseDto(
+            webRequest.getDescription(false),
+            status.value(),
+            "Validation failed",
+            LocalDateTime.now(),
+            errors
+    );
+
+    return new ResponseEntity<>(validationErrorResponseDto, status);
   }
 
   /**

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/GlobalExceptionHandler.java
@@ -53,6 +53,39 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   /**
+   * Handles InvalidNotificationTypeException.
+   */
+  @ExceptionHandler(InvalidNotificationTypeException.class)
+  public ResponseEntity<ErrorResponseDto> handleInvalidNotificationTypeException(
+          Exception exception,
+          WebRequest webRequest
+  ) {
+    return createErrorResponse(exception, webRequest, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * Handles EmailSendingException.
+   */
+  @ExceptionHandler(EmailSendingException.class)
+  public ResponseEntity<ErrorResponseDto> handleEmailSendingException(
+          Exception exception,
+          WebRequest webRequest
+  ) {
+    return createErrorResponse(exception, webRequest, HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  /**
+   * Handles TemplateProcessingException.
+   */
+  @ExceptionHandler(TemplateProcessingException.class)
+  public ResponseEntity<ErrorResponseDto> handleTemplateProcessingException(
+          Exception exception,
+          WebRequest webRequest
+  ) {
+    return createErrorResponse(exception, webRequest, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  /**
    * Handles MethodArgumentNotValidException.
    * This exception is thrown when validation on an argument annotated with @Valid fails.
    *

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/InvalidNotificationTypeException.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/InvalidNotificationTypeException.java
@@ -1,0 +1,25 @@
+package com.clinicwave.clinicwavenotificationservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This class represents a custom exception that is thrown when an invalid notification type is provided.
+ * It is annotated with @ResponseStatus to automatically return a HttpStatus.BAD_REQUEST when thrown.
+ * The exception takes in resourceName, fieldName, and fieldValue as parameters to construct a detailed error message.
+ *
+ * @author aamir on 7/14/24
+ */
+@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Invalid notification type")
+public class InvalidNotificationTypeException extends RuntimeException {
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param resourceName The name of the resource.
+   * @param fieldName    The name of the field.
+   * @param fieldValue   The value of the field.
+   */
+  public InvalidNotificationTypeException(String resourceName, String fieldName, Object fieldValue) {
+    super(String.format("%s not supported with %s : '%s'", resourceName, fieldName, fieldValue));
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/TemplateProcessingException.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/exception/TemplateProcessingException.java
@@ -1,0 +1,25 @@
+package com.clinicwave.clinicwavenotificationservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This exception is thrown when an email template fails to process.
+ * It is annotated with @ResponseStatus to automatically return a HttpStatus.INTERNAL_SERVER_ERROR when thrown.
+ * The exception takes in templateName and errorDetails as parameters to construct a detailed error message.
+ *
+ * @author aamir on 7/14/24
+ */
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "Email Template Processing Failed")
+public class TemplateProcessingException extends RuntimeException {
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param templateName The name of the email template.
+   * @param errorDetails The details of the error that occurred.
+   */
+  public TemplateProcessingException(String templateName, String errorDetails) {
+    super(String.format("Failed to process email template '%s'. Error: %s", templateName, errorDetails)
+    );
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces several enhancements and new exception handling mechanisms to the ClinicWave Notification Service. It adds custom exceptions for specific error scenarios such as email sending failures, invalid notification types, and template processing errors. Additionally, it extends the `GlobalExceptionHandler` to handle these exceptions gracefully and provide more informative responses to the client.

### Changes:
- Added `EmailSendingException` for handling failures in email sending operations.
- Added `InvalidNotificationTypeException` for handling cases where an invalid notification type is provided.
- Added `TemplateProcessingException` for handling errors during email template processing.
- Extended `GlobalExceptionHandler` with `ResponseEntityExceptionHandler` to leverage advanced exception handling capabilities.
- Added exception handling methods in `GlobalExceptionHandler` for `InvalidNotificationTypeException`, `EmailSendingException`, and `TemplateProcessingException`.
- Implemented a method to handle `MethodArgumentNotValidException` in `GlobalExceptionHandler`, providing detailed validation error responses.

### Purpose:
The purpose of this pull request is to enhance the robustness and reliability of the ClinicWave Notification Service by introducing specific exceptions for various error scenarios and improving the global exception handling mechanism. These changes aim to provide clearer, more informative error responses to clients, thereby improving the overall user experience. By handling exceptions in a more granular and informative manner, the service can more effectively communicate issues to clients, facilitating easier debugging and issue resolution. This approach also aligns with best practices for RESTful service design, emphasizing meaningful HTTP status codes and error messages.