### PR TITLE
Add NotificationService Interface and NotificationServiceImpl with unit tests

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/service/NotificationService.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/service/NotificationService.java
@@ -1,0 +1,12 @@
+package com.clinicwave.clinicwavenotificationservice.service;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+
+/**
+ * This interface is a service for sending notifications.
+ *
+ * @author aamir on 7/8/24
+ */
+public interface NotificationService {
+  void sendNotification(NotificationRequestDto notificationRequestDto);
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,55 @@
+package com.clinicwave.clinicwavenotificationservice.service.impl;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+import com.clinicwave.clinicwavenotificationservice.enums.NotificationTypeEnum;
+import com.clinicwave.clinicwavenotificationservice.exception.InvalidNotificationTypeException;
+import com.clinicwave.clinicwavenotificationservice.service.NotificationService;
+import com.clinicwave.clinicwavenotificationservice.strategy.NotificationStrategy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This class is a service class for the Notification entity.
+ * It provides methods to send email notifications.
+ *
+ * @author aamir on 7/8/24
+ */
+@Service
+@Slf4j
+public class NotificationServiceImpl implements NotificationService {
+  private final Map<NotificationTypeEnum, NotificationStrategy> notificationStrategyMap;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param notificationStrategyList The list of notification strategies to be used for sending notifications.
+   */
+  @Autowired
+  public NotificationServiceImpl(List<NotificationStrategy> notificationStrategyList) {
+    // Initialize the notification strategy map with an EnumMap
+    notificationStrategyMap = new EnumMap<>(NotificationTypeEnum.class);
+
+    // Add each notification strategy to the map using its type as the key
+    notificationStrategyList.forEach(strategy -> notificationStrategyMap.put(strategy.getType(), strategy));
+    log.info("Notification strategies initialized: {}", notificationStrategyMap.keySet());
+  }
+
+  /**
+   * Sends a notification using the appropriate strategy based on the notification type.
+   *
+   * @param notificationRequestDto The notification request to be sent.
+   * @throws InvalidNotificationTypeException if the notification type is not supported.
+   */
+  @Override
+  public void sendNotification(NotificationRequestDto notificationRequestDto) {
+    Optional.ofNullable(notificationStrategyMap.get(notificationRequestDto.type()))
+            .orElseThrow(() -> new InvalidNotificationTypeException("NotificationStrategy", "type", notificationRequestDto.type()))
+            .send(notificationRequestDto);
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImplTest.java
@@ -1,0 +1,142 @@
+package com.clinicwave.clinicwavenotificationservice.service.impl;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+import com.clinicwave.clinicwavenotificationservice.enums.NotificationCategoryEnum;
+import com.clinicwave.clinicwavenotificationservice.enums.NotificationTypeEnum;
+import com.clinicwave.clinicwavenotificationservice.exception.InvalidNotificationTypeException;
+import com.clinicwave.clinicwavenotificationservice.strategy.EmailNotificationStrategy;
+import com.clinicwave.clinicwavenotificationservice.strategy.NotificationStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * This class contains unit tests for the NotificationServiceImpl class.
+ *
+ * @author aamir on 7/16/24
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+  private NotificationServiceImpl notificationService;
+
+  @Mock
+  private NotificationStrategy smsNotificationStrategy;
+
+  @Mock
+  private EmailNotificationStrategy emailNotificationStrategy;
+
+  /**
+   * Sets up the test environment before each test.
+   */
+  @BeforeEach
+  void setUp() {
+    when(emailNotificationStrategy.getType()).thenReturn(NotificationTypeEnum.EMAIL);
+    when(smsNotificationStrategy.getType()).thenReturn(NotificationTypeEnum.SMS);
+
+    List<NotificationStrategy> strategies = Arrays.asList(emailNotificationStrategy, smsNotificationStrategy);
+    notificationService = new NotificationServiceImpl(strategies);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationTypeEnum.class, names = {"EMAIL", "SMS"})
+  @DisplayName("sendNotification should use correct strategy")
+  void sendNotification_ShouldUseCorrectStrategy(NotificationTypeEnum type) {
+    NotificationRequestDto requestDto = createNotificationRequestDto(type);
+
+    notificationService.sendNotification(requestDto);
+
+    if (type == NotificationTypeEnum.EMAIL) {
+      verify(emailNotificationStrategy, times(1)).send(requestDto);
+      verify(smsNotificationStrategy, never()).send(any());
+    } else {
+      verify(smsNotificationStrategy, times(1)).send(requestDto);
+      verify(emailNotificationStrategy, never()).send(any());
+    }
+  }
+
+  @Test
+  @DisplayName("sendNotification should throw exception for unsupported type")
+  void sendNotification_WithUnsupportedType_ShouldThrowException() {
+    NotificationRequestDto requestDto = createNotificationRequestDto(NotificationTypeEnum.WEB);
+
+    InvalidNotificationTypeException exception = assertThrows(InvalidNotificationTypeException.class,
+            () -> notificationService.sendNotification(requestDto));
+
+    String expectedMessage = "NotificationStrategy not supported with type : 'WEB'";
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("sendNotification should throw exception for no matching type")
+  void sendNotification_WithNoMatchingType_ShouldThrowException() {
+    notificationService = new NotificationServiceImpl(Collections.singletonList(emailNotificationStrategy));
+    NotificationRequestDto requestDto = createNotificationRequestDto(NotificationTypeEnum.SMS);
+
+    InvalidNotificationTypeException exception = assertThrows(InvalidNotificationTypeException.class,
+            () -> notificationService.sendNotification(requestDto));
+
+    String expectedMessage = "NotificationStrategy not supported with type : 'SMS'";
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("constructNotificationService should allow construction with empty strategy list")
+  void constructNotificationService_WithEmptyStrategyList_ShouldAllowConstruction() {
+    NotificationServiceImpl service = new NotificationServiceImpl(List.of());
+    assertNotNull(service);
+  }
+
+  @Test
+  @DisplayName("sendNotification should throw exception for empty strategy list")
+  void sendNotification_WithEmptyStrategyList_ShouldThrowException() {
+    NotificationServiceImpl service = new NotificationServiceImpl(List.of());
+    NotificationRequestDto requestDto = createNotificationRequestDto(NotificationTypeEnum.EMAIL);
+
+    assertThrows(InvalidNotificationTypeException.class, () -> service.sendNotification(requestDto));
+  }
+
+  @Test
+  @DisplayName("constructNotificationService should use last strategy for duplicate type")
+  void constructNotificationService_WithDuplicateStrategyTypes_ShouldUseLastStrategyForType() {
+    EmailNotificationStrategy duplicateEmailStrategy = mock(EmailNotificationStrategy.class);
+    when(duplicateEmailStrategy.getType()).thenReturn(NotificationTypeEnum.EMAIL);
+
+    NotificationServiceImpl service = new NotificationServiceImpl(Arrays.asList(emailNotificationStrategy, duplicateEmailStrategy));
+    NotificationRequestDto requestDto = createNotificationRequestDto(NotificationTypeEnum.EMAIL);
+
+    service.sendNotification(requestDto);
+
+    verify(duplicateEmailStrategy, times(1)).send(requestDto);
+    verify(emailNotificationStrategy, never()).send(any());
+  }
+
+  /**
+   * Creates a NotificationRequestDto object with the given type.
+   *
+   * @param type the type of the notification
+   * @return the created NotificationRequestDto object
+   */
+  private NotificationRequestDto createNotificationRequestDto(NotificationTypeEnum type) {
+    return new NotificationRequestDto(
+            "recipient@example.com",
+            "Test Subject",
+            "test-template",
+            new HashMap<>(),
+            type,
+            NotificationCategoryEnum.VERIFICATION
+    );
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a comprehensive update to the notification service within the ClinicWave Notification Service project. It adds a new `NotificationService` interface and its implementation, `NotificationServiceImpl`, which leverages a strategy pattern for sending notifications. Additionally, it includes a suite of unit tests for `NotificationServiceImpl` to ensure the correct behavior of notification sending across various scenarios.

### Changes:
- Added `NotificationService` interface to define a contract for sending notifications.
- Implemented `NotificationServiceImpl` to handle notification sending logic using different strategies based on the notification type.
- Introduced an `EnumMap` in `NotificationServiceImpl` for mapping `NotificationTypeEnum` to corresponding `NotificationStrategy` instances.
- Added comprehensive unit tests in `NotificationServiceImplTest` to validate the functionality of `NotificationServiceImpl`, including strategy selection and exception handling.

### Purpose:
The purpose of this pull request is to enhance the ClinicWave Notification Service's flexibility and maintainability by introducing a strategy pattern for notification sending. This approach allows for easy extension and customization of notification handling strategies in the future. The addition of unit tests ensures that the notification service behaves as expected under various conditions, thereby improving the reliability of the notification system. By implementing these changes, the project aligns with best practices for software design, ensuring that the notification service is robust, extensible, and easily testable.