### PR TITLE
Add NotificationController and Tests

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/controller/NotificationController.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package com.clinicwave.clinicwavenotificationservice.controller;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+import com.clinicwave.clinicwavenotificationservice.service.NotificationService;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@Slf4j
+public class NotificationController {
+  private final NotificationService notificationService;
+
+  @Autowired
+  public NotificationController(NotificationService notificationService) {
+    this.notificationService = notificationService;
+  }
+
+  @PostMapping("/send")
+  public ResponseEntity<Void> sendNotification(@Valid @RequestBody NotificationRequestDto notificationRequestDto) {
+    log.info("Received notification request: {}", notificationRequestDto);
+    notificationService.sendNotification(notificationRequestDto);
+    return ResponseEntity.accepted().build();
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/controller/NotificationControllerTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/controller/NotificationControllerTest.java
@@ -1,0 +1,118 @@
+package com.clinicwave.clinicwavenotificationservice.controller;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+import com.clinicwave.clinicwavenotificationservice.enums.NotificationCategoryEnum;
+import com.clinicwave.clinicwavenotificationservice.enums.NotificationTypeEnum;
+import com.clinicwave.clinicwavenotificationservice.exception.EmailSendingException;
+import com.clinicwave.clinicwavenotificationservice.service.NotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * This class contains unit tests for the NotificationController class.
+ *
+ * @author aamir on 7/20/24
+ */
+@WebMvcTest(NotificationController.class)
+class NotificationControllerTest {
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  @MockBean
+  private NotificationService notificationService;
+
+  private NotificationRequestDto notificationRequestDto;
+
+  /**
+   * Constructor-based dependency injection.
+   *
+   * @param mockMvc      The MockMvc object
+   * @param objectMapper The ObjectMapper object
+   */
+  @Autowired
+  public NotificationControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Sets up the test environment before each test.
+   */
+  @BeforeEach
+  void setUp() {
+    Map<String, Object> templateVariables = new HashMap<>();
+    templateVariables.put("name", "John Doe");
+    templateVariables.put("verificationCode", "123456");
+
+    notificationRequestDto = new NotificationRequestDto(
+            "test@example.com",
+            "Test Notification",
+            "test-template",
+            templateVariables,
+            NotificationTypeEnum.EMAIL,
+            NotificationCategoryEnum.VERIFICATION
+    );
+  }
+
+  @Test
+  @DisplayName("POST /api/notifications/send - Success")
+  void testSendNotificationSuccess() throws Exception {
+    doNothing().when(notificationService).sendNotification(any(NotificationRequestDto.class));
+
+    mockMvc.perform(post("/api/notifications/send")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(notificationRequestDto)))
+            .andExpect(status().isAccepted());
+
+    verify(notificationService, times(1)).sendNotification(any(NotificationRequestDto.class));
+  }
+
+  @Test
+  @DisplayName("POST /api/notifications/send - Bad Request")
+  void testSendNotificationBadRequest() throws Exception {
+    NotificationRequestDto invalidDto = new NotificationRequestDto(
+            null, // invalid: null recipient
+            "Test Notification",
+            "test-template",
+            new HashMap<>(),
+            NotificationTypeEnum.EMAIL,
+            NotificationCategoryEnum.VERIFICATION
+    );
+
+    mockMvc.perform(post("/api/notifications/send")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidDto)))
+            .andExpect(status().isBadRequest());
+
+    verify(notificationService, never()).sendNotification(any(NotificationRequestDto.class));
+  }
+
+  @Test
+  @DisplayName("POST /api/notifications/send - Internal Server Error")
+  void testSendNotificationInternalServerError() throws Exception {
+    doThrow(new EmailSendingException("test@example.com", "Test Subject", "Failed to send email"))
+            .when(notificationService).sendNotification(any(NotificationRequestDto.class));
+
+    mockMvc.perform(post("/api/notifications/send")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(notificationRequestDto)))
+            .andExpect(status().isServiceUnavailable());
+
+    verify(notificationService, times(1)).sendNotification(any(NotificationRequestDto.class));
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces significant enhancements to the notification handling mechanism within the ClinicWave Notification Service, alongside the introduction of a new `NotificationController` to manage notification requests. It also adds comprehensive testing for both the service layer and the controller layer to ensure robustness and reliability in notification processing.

### Changes:
- Added a `NotificationController` to handle incoming notification requests through a REST API endpoint.
- Introduced unit tests for `NotificationController` to verify the handling of successful requests, bad requests, and server errors.
- Implemented a `NotificationService` interface and its concrete implementation `NotificationServiceImpl`, utilizing a strategy pattern for flexible notification handling.
- Added unit tests for `NotificationServiceImpl` to ensure correct strategy usage, handling of unsupported notification types, and proper initialization with strategy lists.

### Purpose:
The purpose of this pull request is to solidify the foundation of the ClinicWave Notification Service by ensuring that notifications can be sent through a REST API in a flexible, extensible manner. By introducing a strategy pattern in the service layer, the application can easily adapt to new notification types and methods without significant changes. The addition of a controller layer further encapsulates the notification sending process, providing a clear interface for external requests. The comprehensive testing ensures that both new features work as expected under various scenarios, thereby increasing the reliability and maintainability of the service. This pull request aims to enhance the overall architecture of the ClinicWave Notification Service, making it more robust and adaptable to future requirements.