### PR TITLE
Add fromAddress Field to SmtpSetting

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
@@ -35,6 +35,7 @@ public class SmtpSettingConfig {
       SmtpSetting smtpSetting = new SmtpSetting();
       smtpSetting.setHost("localhost");
       smtpSetting.setPort(1025);
+      smtpSetting.setFromAddress("no-reply@clinicwave.com");
       smtpSetting.setUsername("");
       smtpSetting.setPassword("");
       smtpSetting.setAuth(false);

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSetting.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSetting.java
@@ -27,6 +27,9 @@ public class SmtpSetting {
   private Integer port;
 
   @Column(nullable = false)
+  private String fromAddress;
+
+  @Column(nullable = false)
   private String username;
 
   @Column(nullable = false)

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/service/impl/SmtpSettingServiceImpl.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/service/impl/SmtpSettingServiceImpl.java
@@ -46,6 +46,7 @@ public class SmtpSettingServiceImpl implements SmtpSettingService {
     mailSender.setPassword(setting.getPassword());
 
     Properties props = mailSender.getJavaMailProperties();
+    props.put("mail.smtp.from", setting.getFromAddress());
     props.put("mail.transport.protocol", "smtp");
     props.put("mail.smtp.auth", setting.getAuth().toString());
     props.put("mail.smtp.starttls.enable", setting.getStarttlsEnable().toString());

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSettingTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSettingTest.java
@@ -38,7 +38,8 @@ class SmtpSettingTest {
     smtpSetting = new SmtpSetting();
     smtpSetting.setHost("smtp.gmail.com");
     smtpSetting.setPort(587);
-    smtpSetting.setUsername("aamirshaikh3232@gmail.com");
+    smtpSetting.setFromAddress("no-reply@clinicwave.com");
+    smtpSetting.setUsername("clinicwave");
     smtpSetting.setPassword("password");
     smtpSetting.setAuth(true);
     smtpSetting.setStarttlsEnable(true);
@@ -69,6 +70,7 @@ class SmtpSettingTest {
     assertNotNull(savedSmtpSetting);
     assertEquals(smtpSetting.getHost(), savedSmtpSetting.getHost());
     assertEquals(smtpSetting.getPort(), savedSmtpSetting.getPort());
+    assertEquals(smtpSetting.getFromAddress(), savedSmtpSetting.getFromAddress());
     assertEquals(smtpSetting.getUsername(), savedSmtpSetting.getUsername());
     assertEquals(smtpSetting.getPassword(), savedSmtpSetting.getPassword());
     assertEquals(smtpSetting.getAuth(), savedSmtpSetting.getAuth());
@@ -82,7 +84,8 @@ class SmtpSettingTest {
     smtpSettingRepository.save(smtpSetting);
     smtpSetting.setHost("smtp.mailtrap.io");
     smtpSetting.setPort(2525);
-    smtpSetting.setUsername("johndoe@email.com");
+    smtpSetting.setFromAddress("no-reply@test.com");
+    smtpSetting.setUsername("admin");
     smtpSetting.setPassword("password123");
     smtpSetting.setAuth(false);
     smtpSetting.setStarttlsEnable(false);
@@ -92,6 +95,7 @@ class SmtpSettingTest {
     assertNotNull(updatedSmtpSetting);
     assertEquals(smtpSetting.getHost(), updatedSmtpSetting.getHost());
     assertEquals(smtpSetting.getPort(), updatedSmtpSetting.getPort());
+    assertEquals(smtpSetting.getFromAddress(), updatedSmtpSetting.getFromAddress());
     assertEquals(smtpSetting.getUsername(), updatedSmtpSetting.getUsername());
     assertEquals(smtpSetting.getPassword(), updatedSmtpSetting.getPassword());
     assertEquals(smtpSetting.getAuth(), updatedSmtpSetting.getAuth());

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/service/impl/SmtpSettingServiceImplTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/service/impl/SmtpSettingServiceImplTest.java
@@ -44,6 +44,7 @@ class SmtpSettingServiceImplTest {
     smtpSetting = new SmtpSetting();
     smtpSetting.setHost("smtp.example.com");
     smtpSetting.setPort(587);
+    smtpSetting.setFromAddress("no-reply@test.com");
     smtpSetting.setUsername("testuser");
     smtpSetting.setPassword("password");
     smtpSetting.setAuth(true);
@@ -68,6 +69,7 @@ class SmtpSettingServiceImplTest {
     assertEquals(smtpSetting.getPassword(), mailSender.getPassword());
 
     Properties props = mailSender.getJavaMailProperties();
+    assertEquals("no-reply@test.com", props.getProperty("mail.smtp.from"));
     assertEquals("smtp", props.getProperty("mail.transport.protocol"));
     assertEquals(smtpSetting.getAuth().toString(), props.getProperty("mail.smtp.auth"));
     assertEquals(smtpSetting.getStarttlsEnable().toString(), props.getProperty("mail.smtp.starttls.enable"));


### PR DESCRIPTION
### Description:
This pull request introduces the `fromAddress` field to the `SmtpSetting` domain class and updates related configurations and tests to handle this new field.

### Changes:
- Added a new `fromAddress` field in the `SmtpSetting` domain class.
- Updated the `SmtpSettingTest` class to include test cases for the `fromAddress` field.
- Modified existing test cases to validate the `fromAddress` field in the `SmtpSetting` domain.
- Added the `fromAddress` field initialization in the `SmtpSettingConfig` class.
- Set the `fromAddress` to `no-reply@clinicwave.com` in the default SMTP configuration.
- Added the `mail.smtp.from` property to the `SmtpSettingServiceImpl` to set the `fromAddress`.
- Updated the `SmtpSettingServiceImplTest` class to include assertions for the `fromAddress` property.

### Purpose:
The purpose of this pull request is to ensure that the `fromAddress` is correctly set and used in email notifications, improving the professionalism and reliability of the email communication system.

This issue fixes #11.