### PR TITLE
 Use Mailtrap for email testing instead of Mailhog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/secrets.properties

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
@@ -4,6 +4,7 @@ import com.clinicwave.clinicwavenotificationservice.domain.SmtpSetting;
 import com.clinicwave.clinicwavenotificationservice.repository.SmtpSettingRepository;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -14,6 +15,12 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class SmtpSettingConfig {
+  @Value("${mailtrap.username}")
+  private String mailtrapUsername;
+
+  @Value("${mailtrap.password}")
+  private String mailtrapPassword;
+
   private final SmtpSettingRepository smtpSettingRepository;
 
   /**
@@ -33,13 +40,13 @@ public class SmtpSettingConfig {
   public void initializeSmtpSettings() {
     if (smtpSettingRepository.count() == 0) {
       SmtpSetting smtpSetting = new SmtpSetting();
-      smtpSetting.setHost("localhost");
-      smtpSetting.setPort(1025);
+      smtpSetting.setHost("sandbox.smtp.mailtrap.io");
+      smtpSetting.setPort(2525);
       smtpSetting.setFromAddress("no-reply@clinicwave.com");
-      smtpSetting.setUsername("");
-      smtpSetting.setPassword("");
-      smtpSetting.setAuth(false);
-      smtpSetting.setStarttlsEnable(false);
+      smtpSetting.setUsername(mailtrapUsername);
+      smtpSetting.setPassword(mailtrapPassword);
+      smtpSetting.setAuth(true);
+      smtpSetting.setStarttlsEnable(true);
       smtpSetting.setIsActive(true);
       smtpSettingRepository.save(smtpSetting);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ server.port=8081
 
 # Active profile
 spring.profiles.active=dev
+
+spring.config.import=secrets.properties


### PR DESCRIPTION
### Description:
This pull request introduces changes to integrate Mailtrap for email testing by configuring SMTP settings in the `SmtpSettingConfig` class and managing sensitive credentials using a `secrets.properties` file.

### Changes:
- Added `src/main/resources/secrets.properties` to store Mailtrap's `username` and `password`.
- Updated `.gitignore` to exclude `secrets.properties` from version control.
- Modified `application.properties` to import `secrets.properties`.
- Added `@Value` annotations in `SmtpSettingConfig` to inject Mailtrap credentials.
- Updated SMTP settings to use Mailtrap's `sandbox.smtp.mailtrap.io` and port `2525`.
- Enabled `auth` and `starttls` for secure email transmission.

### Purpose:
The purpose of this pull request is to replace the current dependency on Mailhog with Mailtrap, an online email testing tool. This enhancement eliminates the need for running Docker and Mailhog containers, simplifying the email testing setup and improving the overall development workflow. 

This PR solves issue #13.
