### PR TITLE
    Add application-docker.properties file and configure PostgreSQL container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,14 @@
 version: "3"
 services:
-    mailhog:
-        image: mailhog/mailhog:latest
+    db:
+        container_name: clinicwave-notification-postgres
+        image: postgres:latest
         restart: always
+        environment:
+            POSTGRES_DB: clinicwave-notification
+            POSTGRES_USER: root
+            POSTGRES_PASSWORD: root
+        volumes:
+            - ./data:/var/lib/postgresql/data
         ports:
-            - "1025:1025"
-            - "8025:8025"
+            - "5433:5432"

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,8 @@
+# Datasource configuration
+spring.datasource.url=jdbc:postgresql://localhost:5433/clinicwave-notification
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=root
+spring.datasource.password=root
+
+# JPA database platform configuration
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
### Description:
This pull request introduces the configuration of a PostgreSQL container for the notification service and the addition of an `application-docker.properties` file for database connectivity.

### Changes:
- Added a PostgreSQL container to the `docker-compose.yml` with the name `clinicwave-notification-postgres`, mapping container port 5432 to host port 5433 to avoid conflicts with the existing `clinicwave-user-management-postgres` container.
- Updated `pom.xml` to include the `postgresql` dependency for runtime database connectivity.
- Created an `application-docker.properties` file with essential datasource configuration, including JDBC URL, driver class name, username, and password.
- Configured the JPA database platform in `application-docker.properties` to use PostgreSQL.

### Purpose:
The purpose of this pull request is to set up a dedicated PostgreSQL container for the notification service, ensuring that it runs independently of other services, and to provide the necessary configuration for connecting to the database in a Docker environment. This PR addresses and resolves issue #17.
