### PR TITLE
Implement Kafka Consumer for Notification Events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/config/KafkaConsumerConfig.java
@@ -1,0 +1,64 @@
+package com.clinicwave.clinicwavenotificationservice.config;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is responsible for configuring the Kafka Consumer.
+ * It sets the bootstrap servers, group ID, key deserializer, and value deserializer.
+ *
+ * @author aamir on 8/21/24
+ */
+@Configuration
+public class KafkaConsumerConfig {
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  private static final String GROUP_ID = "notification-group";
+
+  /**
+   * This method creates a ConsumerFactory object with the configuration properties.
+   *
+   * @return ConsumerFactory object
+   */
+  @Bean
+  public ConsumerFactory<String, NotificationRequestDto> consumerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.clinicwave.clinicwavenotificationservice.dto");
+    props.put(JsonDeserializer.TYPE_MAPPINGS, "notificationRequest:com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto");
+
+    return new DefaultKafkaConsumerFactory<>(
+            props,
+            new StringDeserializer(),
+            new ErrorHandlingDeserializer<>(new JsonDeserializer<>(NotificationRequestDto.class))
+    );
+  }
+
+  /**
+   * This method creates a ConcurrentKafkaListenerContainerFactory object with the ConsumerFactory object.
+   *
+   * @return ConcurrentKafkaListenerContainerFactory object
+   */
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, NotificationRequestDto> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, NotificationRequestDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory());
+    return factory;
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImpl.java
@@ -7,6 +7,7 @@ import com.clinicwave.clinicwavenotificationservice.service.NotificationService;
 import com.clinicwave.clinicwavenotificationservice.strategy.NotificationStrategy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import java.util.EnumMap;
@@ -25,6 +26,9 @@ import java.util.Optional;
 public class NotificationServiceImpl implements NotificationService {
   private final Map<NotificationTypeEnum, NotificationStrategy> notificationStrategyMap;
 
+  private static final String TOPIC_NAME = "notification-topic";
+  private static final String GROUP_ID = "notification-group";
+
   /**
    * Constructor for dependency injection.
    *
@@ -38,6 +42,17 @@ public class NotificationServiceImpl implements NotificationService {
     // Add each notification strategy to the map using its type as the key
     notificationStrategyList.forEach(strategy -> notificationStrategyMap.put(strategy.getType(), strategy));
     log.info("Notification strategies initialized: {}", notificationStrategyMap.keySet());
+  }
+
+  /**
+   * Kafka listener method to handle notification requests.
+   *
+   * @param notificationRequestDto The notification request to be handled.
+   */
+  @KafkaListener(topics = TOPIC_NAME, groupId = GROUP_ID)
+  public void handleNotification(NotificationRequestDto notificationRequestDto) {
+    log.info("Received notification request: {}", notificationRequestDto);
+    sendNotification(notificationRequestDto);
   }
 
   /**

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,3 +9,6 @@ spring.h2.console.enabled=true
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Kafka configuration
+spring.kafka.bootstrap-servers=localhost:9092

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -6,3 +6,6 @@ spring.datasource.password=root
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# Kafka configuration
+spring.kafka.bootstrap-servers=localhost:9093

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/config/KafkaConsumerConfigTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/config/KafkaConsumerConfigTest.java
@@ -1,0 +1,76 @@
+package com.clinicwave.clinicwavenotificationservice.config;
+
+import com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This class tests the KafkaConsumerConfig class.
+ * It tests the configuration of the ConsumerFactory and KafkaListenerContainerFactory beans.
+ *
+ * @author aamir on 8/31/24
+ */
+@SpringBootTest
+class KafkaConsumerConfigTest {
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  private final KafkaConsumerConfig kafkaConsumerConfig;
+  private final ConsumerFactory<String, NotificationRequestDto> consumerFactory;
+
+  /**
+   * Constructor for dependency injection.
+   *
+   * @param kafkaConsumerConfig The KafkaConsumerConfig object to be tested
+   * @param consumerFactory     The ConsumerFactory object to be tested
+   */
+  @Autowired
+  public KafkaConsumerConfigTest(KafkaConsumerConfig kafkaConsumerConfig, ConsumerFactory<String, NotificationRequestDto> consumerFactory) {
+    this.kafkaConsumerConfig = kafkaConsumerConfig;
+    this.consumerFactory = consumerFactory;
+  }
+
+  @Test
+  @DisplayName("Test KafkaConsumerConfig bean")
+  void testKafkaConsumerConfig() {
+    assertNotNull(kafkaConsumerConfig);
+  }
+
+  @Test
+  @DisplayName("Test KafkaConsumerConfig properties")
+  void testConsumerFactoryConfiguration() {
+    assertNotNull(consumerFactory);
+
+    // Test if the ConsumerFactory is correctly configured
+    Map<String, Object> configs = consumerFactory.getConfigurationProperties();
+    assertEquals(bootstrapServers, configs.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+    assertEquals("notification-group", configs.get(ConsumerConfig.GROUP_ID_CONFIG));
+    assertEquals(StringDeserializer.class, configs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+    assertEquals(JsonDeserializer.class, configs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+    assertEquals("com.clinicwave.clinicwavenotificationservice.dto",
+            configs.get(JsonDeserializer.TRUSTED_PACKAGES));
+    assertEquals("notificationRequest:com.clinicwave.clinicwavenotificationservice.dto.NotificationRequestDto",
+            configs.get(JsonDeserializer.TYPE_MAPPINGS));
+  }
+
+  @Test
+  @DisplayName("kafkaListenerContainerFactory creates a ConcurrentKafkaListenerContainerFactory with correct ConsumerFactory")
+  void kafkaListenerContainerFactoryCreatesConcurrentKafkaListenerContainerFactoryWithCorrectConsumerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, NotificationRequestDto> factory = kafkaConsumerConfig.kafkaListenerContainerFactory();
+    assertNotNull(factory);
+    assertEquals(consumerFactory, factory.getConsumerFactory());
+  }
+}

--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/service/impl/NotificationServiceImplTest.java
@@ -50,6 +50,19 @@ class NotificationServiceImplTest {
     notificationService = new NotificationServiceImpl(strategies);
   }
 
+  @Test
+  @DisplayName("handleNotification should process the received notification request")
+  void handleNotification_ShouldProcessReceivedNotificationRequest() {
+    NotificationRequestDto requestDto = createNotificationRequestDto(NotificationTypeEnum.EMAIL);
+
+    // We need to spy on the notificationService to verify the sendNotification method is called
+    NotificationServiceImpl spyNotificationService = spy(notificationService);
+
+    spyNotificationService.handleNotification(requestDto);
+
+    verify(spyNotificationService, times(1)).sendNotification(requestDto);
+  }
+
   @ParameterizedTest
   @EnumSource(value = NotificationTypeEnum.class, names = {"EMAIL", "SMS"})
   @DisplayName("sendNotification should use correct strategy")


### PR DESCRIPTION
### Description:
This pull request introduces Kafka integration into the notification service by adding necessary dependencies, configurations, and implementing a Kafka listener to handle incoming notification requests.

### Changes:
- Added `spring-kafka` dependency to `pom.xml`.
- Updated `application-dev.properties` and `application-docker.properties` to include Kafka bootstrap servers configuration.
- Created `KafkaConsumerConfig` class to configure Kafka consumer properties such as bootstrap servers, group ID, key deserializer, and value deserializer.
- Added `KafkaConsumerConfigTest` to ensure proper configuration of the Kafka consumer.
- Implemented a `KafkaListener` method in `NotificationServiceImpl` to process messages from the `notification-topic`.
- Updated `NotificationServiceImplTest` to include tests for the Kafka listener method.

### Purpose:
The purpose of this pull request is to integrate Kafka into the notification service, allowing it to listen for and process notification requests sent to a Kafka topic. This ensures that the notification service can handle distributed messaging scenarios effectively, enhancing the scalability and reliability of the system.

This PR solves issue #16.
