### PR TITLE
Add JPA Auditing Support to Notification Service

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/ClinicwaveNotificationServiceApplication.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/ClinicwaveNotificationServiceApplication.java
@@ -2,8 +2,10 @@ package com.clinicwave.clinicwavenotificationservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 public class ClinicwaveNotificationServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/audit/Audit.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/audit/Audit.java
@@ -1,0 +1,62 @@
+package com.clinicwave.clinicwavenotificationservice.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * This abstract class provides auditing capabilities for entities.
+ * It includes fields for tracking the creation and modification of entities.
+ * Entities that need to be audited can extend this class.
+ *
+ * @author aamir on 3/24/24
+ */
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+public abstract class Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * The timestamp when the entity was created.
+   * This field is not updatable.
+   */
+  @CreatedDate
+  @Column(updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  /**
+   * The user who created the entity.
+   * This field is not updatable.
+   */
+  @CreatedBy
+  @Column(updatable = false, nullable = false, length = 20)
+  private String createdBy;
+
+  /**
+   * The timestamp when the entity was last updated.
+   */
+  @LastModifiedDate
+  @Column(insertable = false)
+  private LocalDateTime updatedAt;
+
+  /**
+   * The user who last updated the entity.
+   */
+  @LastModifiedBy
+  @Column(insertable = false, length = 20)
+  private String updatedBy;
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/audit/AuditorAwareImpl.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/audit/AuditorAwareImpl.java
@@ -1,0 +1,29 @@
+package com.clinicwave.clinicwavenotificationservice.audit;
+
+import lombok.NonNull;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * This class provides the current auditor for auditing purposes.
+ * It implements the AuditorAware interface from Spring Data JPA.
+ *
+ * @author aamir on 3/24/24
+ */
+@Component(value = "auditorAwareImpl")
+public class AuditorAwareImpl implements AuditorAware<String> {
+  /**
+   * The getCurrentAuditor method returns the username of the current user.
+   * In this implementation, the username is hardcoded as "user".
+   * TODO: method should return the username of the currently authenticated user.
+   *
+   * @return the username of the current auditor
+   */
+  @Override
+  @NonNull
+  public Optional<String> getCurrentAuditor() {
+    return Optional.of("user");
+  }
+}

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSetting.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/domain/SmtpSetting.java
@@ -1,5 +1,6 @@
 package com.clinicwave.clinicwavenotificationservice.domain;
 
+import com.clinicwave.clinicwavenotificationservice.audit.Audit;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,7 +16,7 @@ import lombok.*;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-public class SmtpSetting {
+public class SmtpSetting extends Audit {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;


### PR DESCRIPTION
### Description:
This pull request introduces JPA auditing capabilities to the Notification Service. By implementing auditing, we can track the creation and modification timestamps along with user information for entities. This enhancement will improve data traceability and maintainability within the application.

### Changes:
- Created the `Audit` abstract class in the package `com.clinicwave.clinicwavenotificationservice.audit` to provide auditing capabilities for entities, including fields for tracking creation and modification timestamps and user information.
- Implemented the `AuditorAwareImpl` class to provide the current auditor's username, which will be used for auditing purposes (currently hardcoded as "user").
- Added the `@EnableJpaAuditing` annotation in the `ClinicwaveNotificationServiceApplication` class to enable JPA auditing features.
- Updated the `SmtpSetting` entity to extend the `Audit` class, allowing it to inherit fields for tracking creation and modification timestamps and user information.

### Purpose:
The purpose of this pull request is to enhance the auditing functionality within the Notification Service, ensuring that all relevant entities can track their creation and modification details. This will facilitate better monitoring of changes, improve accountability, and support future enhancements related to auditing and user activity tracking. By implementing these changes, we aim to improve the overall reliability and maintainability of the application, addressing issue #20 effectively.