### PR TITLE
Add Environment Variables and Externalize Credentials in Notification Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 .vscode/
 
 src/main/resources/secrets.properties
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
         restart: always
         environment:
             POSTGRES_DB: clinicwave-notification
-            POSTGRES_USER: root
-            POSTGRES_PASSWORD: root
+            POSTGRES_USER: ${DOCKER_POSTGRES_USERNAME}
+            POSTGRES_PASSWORD: ${DOCKER_POSTGRES_PASSWORD}
         volumes:
             - ./data:/var/lib/postgresql/data
         ports:

--- a/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
+++ b/src/main/java/com/clinicwave/clinicwavenotificationservice/config/SmtpSettingConfig.java
@@ -15,10 +15,10 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class SmtpSettingConfig {
-  @Value("${mailtrap.username}")
+  @Value("${MAILTRAP_USERNAME}")
   private String mailtrapUsername;
 
-  @Value("${mailtrap.password}")
+  @Value("${MAILTRAP_PASSWORD}")
   private String mailtrapPassword;
 
   private final SmtpSettingRepository smtpSettingRepository;

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,8 +1,8 @@
 # Datasource configuration
 spring.datasource.url=jdbc:postgresql://localhost:5433/clinicwave-notification
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.username=${DOCKER_POSTGRES_USERNAME}
+spring.datasource.password=${DOCKER_POSTGRES_PASSWORD}
 
 # JPA database platform configuration
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
### Description:
This pull request introduces changes to externalize sensitive credentials and utilize environment variables in the Notification Service to enhance security and prevent hardcoded credentials.

### Changes:
- Added `.env` and `secrets.properties` to `.gitignore` to ensure these sensitive files are not tracked in version control.
- Updated `docker-compose.yml` to use environment variables for PostgreSQL credentials, replacing hardcoded values.
- Modified `SmtpSettingConfig.java` to rename Mailtrap credentials and fetch from secrets.properties.
- Updated `application-docker.properties` to reference PostgreSQL credentials via environment variables.

### Purpose:
The purpose of this pull request is to improve the security of the Notification Service by externalizing sensitive information such as database and SMTP credentials. By moving these credentials into environment variables and separate properties files, we reduce the risk of exposing them in the codebase and version control, addressing the security concerns flagged by SonarCloud. 

This PR fixes issue #22.
