### PR TITLE
Enhance Documentation for Contributor Onboarding for Clinicwave Notification Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Kafka.
 
 - Docker
 - Java 17 or higher
-- Maven 3.6.0 or higher
+- [Mailtrap](https://mailtrap.io) account for email testing
 
 ### Steps
+
+Before proceeding, please read the [contributing guidelines](CONTRIBUTING.md).
 
 1. Clone the repository:
    ```sh
@@ -53,39 +55,36 @@ Kafka.
 
 2. Run docker-compose to start the required services:
     ```sh
-    docker-compose up -d
+    docker compose up -d
     ```
 
-3. Create `.env` in the project root and add the following environment variables:
-   ```sh
-   DOCKER_POSTGRES_USERNAME=<your-docker-postgres-username>
-   DOCKER_POSTGRES_PASSWORD=<your-docker-postgres-password>
-   ```
-4. Create `secrets.properties` in the `src/main/resources` directory and add the following properties:
+3. Update the existing `secrets.properties` file in the `src/main/resources` directory with your Mailtrap credentials:
    ```sh
    MAILTRAP_USERNAME=<your-mailtrap-username>
    MAILTRAP_PASSWORD=<your-mailtrap-password>
-   DOCKER_POSTGRES_USERNAME=<your-docker-postgres-username>
-   DOCKER_POSTGRES_PASSWORD=<your-docker-postgres-password>
    ```
-   **Note:** You need to sign up for a [Mailtrap](https://mailtrap.io) account to get the `MAILTRAP_USERNAME` and `MAILTRAP_PASSWORD`. After signing up:
-   - Create a new inbox.
-   - Go to the "Integration" tab.
-   - Choose "SMTP" integration.
-   - Copy the `username` and paste it into `MAILTRAP_USERNAME` in `secrets.properties`.
-   - Copy the `password` and paste it into `MAILTRAP_PASSWORD` in `secrets.properties`.
+   **Note:** You need to sign up for a [Mailtrap](https://mailtrap.io) account to get the `MAILTRAP_USERNAME` and
+   `MAILTRAP_PASSWORD`. After signing up:
+    - Create a new inbox.
+    - Go to the "Integration" tab.
+    - Choose "SMTP" integration.
+    - Copy the `username` and paste it into `MAILTRAP_USERNAME` in `secrets.properties`.
+    - Copy the `password` and paste it into `MAILTRAP_PASSWORD` in `secrets.properties`.
 
-5. Build the project:
+4. Build the project:
     ```sh
-    mvn clean install
+    ./mvnw clean install
     ```
-6. Run the application:
+5. Run the application:
     ```sh
-    mvn spring-boot:run
+    ./mvnw spring-boot:run -Dspring-boot.run.profiles=docker
     ```
-7. Testing the application:
+
+Alternatively, you can use the provided `start-backend.sh` script to start the backend:
+
+- Run the script to start the backend:
     ```sh
-    mvn test
+    ./installer/start-backend.sh
     ```
 
 ### API Endpoints
@@ -96,7 +95,8 @@ Kafka.
 
 ### Contributing
 
-We welcome contributions to this project! If you'd like to contribute, please read our [contributing guidelines](CONTRIBUTING.md) first.
+We welcome contributions to this project! If you'd like to contribute, please read
+our [contributing guidelines](CONTRIBUTING.md) first.
 
 ### Contact
 

--- a/installer/start-backend.sh
+++ b/installer/start-backend.sh
@@ -7,7 +7,7 @@ cd ../ || exit
 echo "Starting the services..."
 docker compose up -d
 
-# Wait a few seconds to ensure the services is up
+# Wait a few seconds to ensure the services are up
 sleep 10
 
 # Run the Spring Boot application locally


### PR DESCRIPTION
### Description:
This pull request introduces enhancements to the documentation, aimed at making it easier for contributors to set up the backend environment for the project.

### Changes:
- Added a requirement for a Mailtrap account in the "Prerequisites" section for email testing.
- Updated instructions to prompt users to read the contributing guidelines before proceeding.
- Updated the Docker command from `docker-compose` to `docker compose` for consistency.
- Removed outdated instructions for creating `.env` and `secrets.properties` manually.
- Included updated instructions for adding Mailtrap credentials in `secrets.properties`.
- Updated build and run instructions to use `./mvnw` for better compatibility.
- Added an alternative method to start the backend using the `start-backend.sh` script.
- Improved the overall flow and formatting of the documentation for better readability.

### Purpose:
The purpose of this pull request is to streamline the setup process for new contributors by providing clear, updated, and easy-to-follow instructions. This ensures that all required steps are covered, avoiding any confusion related to environment setup, especially with services like Mailtrap. By refining the setup instructions and offering an alternative method to start the backend, this PR aims to reduce the time and effort needed for contributors to get started with the backend service.

This PR solves #28.
