### PR TITLE
Add stop-backend.sh script to gracefully stop backend services

### DIFF
--- a/installer/stop-backend.sh
+++ b/installer/stop-backend.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Navigate to the parent directory where mvnw is located
+cd ../ || exit
+
+# Stop the Spring Boot application gracefully
+echo "Stopping the Spring Boot backend..."
+pkill -f 'spring-boot:run'
+
+# Stop the database service and other services using Docker
+echo "Stopping the services..."
+docker compose down
+
+# Provide feedback
+if [ $? -eq 0 ]; then
+    echo "Backend and services stopped successfully."
+else
+    echo "Failed to stop the backend or services. Please check for any errors."
+fi


### PR DESCRIPTION
### Description:
This pull request introduces a new script `stop-backend.sh` to the codebase, which provides a convenient way to stop the backend services for the ClinicWave Notification Service. The script ensures a graceful shutdown of the Spring Boot application and stops any associated Docker services, ensuring a clean and orderly stop process.

### Changes:
- Added `stop-backend.sh` script to terminate the running Spring Boot instance using `pkill -f 'spring-boot:run'`.
- Included a step in the script to stop the database service and other Docker services using `docker compose down`.
- Added feedback messages to indicate the success or failure of stopping the services.

### Purpose:
The purpose of this pull request is to provide an easier and more efficient way to stop the backend services for the ClinicWave Notification Service. With this script, developers and maintainers can ensure that the Spring Boot application shuts down gracefully and that Docker services are stopped properly, minimizing potential issues related to incomplete shutdowns. This approach simplifies the process and helps maintain a clean development environment, improving workflow efficiency.

This PR solves #30.
