### PR TITLE
Add Documentation for Executable Permissions and Stopping Backend in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,57 @@ Before proceeding, please read the [contributing guidelines](CONTRIBUTING.md).
     ./mvnw spring-boot:run -Dspring-boot.run.profiles=docker
     ```
 
-Alternatively, you can use the provided `start-backend.sh` script to start the backend:
+6. Alternatively, you can use the provided `start-backend.sh` script to start the backend
 
-- Run the script to start the backend:
-    ```sh
-    ./installer/start-backend.sh
-    ```
+   - Ensure the `start-backend.sh` script has execute permissions. If not, grant execute permissions:
+       ```sh
+       cd installer
+       chmod +x start-backend.sh
+       ```
+
+   - Run the script to start the backend:
+       ```sh
+       ./installer/start-backend.sh
+       ```
+
+## Stopping the service
+
+To stop the backend service, you have multiple options:
+
+1. Stop Through the User Interface:
+
+    - If your application has a user interface with a stop button, you can simply click the stop button to gracefully
+      terminate the backend service.
+
+2. Using Docker Compose:
+
+    - Navigate to the service directory and run the following command to stop the services started by Docker Compose:
+
+        ```sh
+        cd clinicwave-notification-service
+        docker compose down
+        ```
+
+    - This command stops and removes the containers created by `docker compose up -d`.
+
+3. Using the Provided Script:
+
+    - You can stop the backend using the provided `stop-backend.sh` script.
+
+    - Ensure the `stop-backend.sh` script has execute permissions. If not, grant execute permissions:
+        ```sh
+        cd installer
+        chmod +x stop-backend.sh
+        ```
+
+    - Run the script to stop the backend:
+
+       ```sh
+       cd installer
+       ./stop-backend.sh
+        ```
+
+    - This script will terminate the Spring Boot application and stop any related services as defined in the script.
 
 ### API Endpoints
 


### PR DESCRIPTION
### Description:
This pull request introduces updates to the README.md file to include instructions for granting executable permissions to `start-backend.sh` and `stop-backend.sh` scripts, as well as detailed steps for stopping the backend service manually and via the `stop-backend.sh` script.

### Changes:
- Added instructions for granting executable permissions to `start-backend.sh` in the README.
- Added steps for stopping the backend service manually through the user interface.
- Added instructions for stopping the backend using Docker Compose.
- Added guidance on using the `stop-backend.sh` script to stop the backend.
- Included instructions for granting executable permissions to `stop-backend.sh` before running it.

### Purpose:
The purpose of this pull request is to improve the user experience and clarity of the setup process by providing detailed instructions for managing the backend service. This includes ensuring that users understand how to grant executable permissions to the necessary scripts and the different options available for stopping the backend service. These changes aim to make the process smoother and prevent potential issues related to script execution.

This PR solves #32.