### PR TITLE
Add Spring Boot Test Annotations and Configure MockMvc in NotificationControllerTest

### DIFF
--- a/src/test/java/com/clinicwave/clinicwavenotificationservice/controller/NotificationControllerTest.java
+++ b/src/test/java/com/clinicwave/clinicwavenotificationservice/controller/NotificationControllerTest.java
@@ -10,7 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,7 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author aamir on 7/20/24
  */
-@WebMvcTest(NotificationController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 class NotificationControllerTest {
   private final MockMvc mockMvc;
   private final ObjectMapper objectMapper;


### PR DESCRIPTION
This pull request introduces changes to the NotificationControllerTest class to resolve issues related to failing tests caused by improper application context initialization.

### Changes:
- Added `@SpringBootTest` annotation to load the full application context for integration testing.
- Added `@AutoConfigureMockMvc` annotation to configure MockMvc for the test class.
- Replaced `@WebMvcTest` with a more comprehensive testing setup.

### Purpose:
The purpose of this pull request is to ensure the `NotificationControllerTest` class is properly configured for integration testing. By loading the full application context and correctly configuring `MockMvc`, these changes address the errors encountered during test execution and improve the stability and reliability of the test suite.

This pull request solves #34.
